### PR TITLE
Added Option to Enable/Disable Swagger on Navbar

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,11 +9,12 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 spring.liquibase.url=jdbc:h2:file:./target/db-development
 spring.liquibase.user=sa

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -14,7 +14,7 @@ app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/pr
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
 
-app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 
 spring.liquibase.url=jdbc:h2:file:./target/db-development
 spring.liquibase.user=sa

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -8,3 +8,5 @@ spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -9,4 +9,4 @@ spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
 spring.liquibase.enabled=true
 
-app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}


### PR DESCRIPTION
In this PR, I changed the application-development and application-production files so that when the  SHOW_SWAGGER_UI_LINK is set to true, the Swagger link shows up on the Navbar, and when the variable is set to false, then the link is not present in the Navbar.

Closes #6 