### PR TITLE
Completion of Expose-Commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-gi
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION=16.20.0
 RUN apk add curl
 RUN apk add bash
 RUN apk add maven
+RUN apk add git
 RUN apk add --no-cache libstdc++
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
@@ -18,10 +19,8 @@ ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
+
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN node --version
 RUN npm --version
 
 COPY . /home/app
-
+gi
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
+    
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,30 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                            
+                    </includeOnlyProperties>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 
     <build>
         <plugins>
-            <plugin>
+                        <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
                 <version>8.0.2</version>
@@ -167,7 +167,7 @@
                         <includeOnlyProperties>
                             <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
                             <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
-                            
+                            <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
                     </includeOnlyProperties>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>

--- a/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/organic/models/SystemInfo.java
@@ -14,4 +14,7 @@ public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
   private String sourceRepo;
+  private String githubUrl;
+  private String commitId;
+  private String commitMessage;
 }

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -27,8 +27,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo}")
-  private String sourceRepo = "https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4";
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")
   private String commitMessage;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -48,6 +48,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     .commitMessage(this.commitMessage)
     .commitId(this.commitId)
     .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -27,7 +27,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-organic}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -23,13 +23,26 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   private boolean showSwaggerUILink;
 
   @Value("${app.sourceRepo}")
-  private String sourceRepo = "https://github.com/ucsb-cs156/proj-organic";
+  private String sourceRepo = "https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4";
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
 
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
-    .sourceRepo(this.sourceRepo)
+    .sourceRepo("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4")
+    .commitMessage(this.commitMessage)
+    .commitId(this.commitId)
+    .githubUrl(githubUrl("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4", this.commitId))
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImpl.java
@@ -4,6 +4,8 @@ package edu.ucsb.cs156.organic.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.organic.models.SystemInfo;
@@ -14,6 +16,9 @@ import edu.ucsb.cs156.organic.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+        @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")
@@ -39,10 +44,10 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
-    .sourceRepo("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4")
+    .sourceRepo(this.sourceRepo)
     .commitMessage(this.commitMessage)
     .commitId(this.commitId)
-    .githubUrl(githubUrl("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4", this.commitId))
+    .githubUrl(githubUrl(this.sourceRepo, this.commitId))
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.organic.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-organic", si.getSourceRepo());
+    assertEquals("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4", si.getSourceRepo());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
   }
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4", "abcdef12345"),
+        "https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
 
+}
 }

--- a/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import edu.ucsb.cs156.organic.models.SystemInfo;
 
-// The unit under test relies on property values
+// The unit under test relies on property values 
 // For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
 
 

--- a/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/SystemInfoServiceImplTests.java
@@ -30,7 +30,7 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4", si.getSourceRepo());
+    assertEquals("https://github.com/ucsb-cs156/proj-organic", si.getSourceRepo());
     assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
     assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
     assertTrue(si.getGithubUrl().contains("/commit/"));


### PR DESCRIPTION
Displays last commit message and commit Id from github at /api/systemInfo to track development. 


Close #2 
Admin properties have not been implemented for group members but it is not required for checking
Link: https://organic-elijahcanderson-dev.dokku-12.cs.ucsb.edu/api/systemInfo 

Below is the last commit message and the commit Id at the time of upload. 

If wanting to go from home link, you have to manually enter /api/systemInfo

<img width="626" alt="Screen Shot 2024-05-22 at 6 01 48 PM" src="https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/92130195/c7ae61dd-186f-4448-ba82-292c5c9cfab0">



