### PR TITLE
Upgrading Backend to Spring-Boot 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>3.2.5</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
-            <version>3.0.1</version>
+            <version>4.1.3</version>
         </dependency>
         <dependency>
             <groupId>me.paulschwarz</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.1.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
@@ -92,8 +92,8 @@
 
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.7.0</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
 
         <dependency>
@@ -168,6 +168,7 @@
                         <exclude>**/edu/ucsb/cs156/organic/controllers/FrontendProxyController.*</exclude>
                         <exclude>**/edu/ucsb/cs156/organic/services/CurrentUserServiceImpl.*</exclude>
                         <exclude>**/edu/ucsb/cs156/organic/OrganicApplication.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/organic/services/GrantedAuthoritiesService.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -255,6 +256,8 @@
                         <param>edu.ucsb.cs156.organic.config.SecurityConfig</param>
                         <param>edu.ucsb.cs156.organic.config.SecurityConfig.MyCsrfRequestMatcher</param>
                         <param>edu.ucsb.cs156.organic.services.GrantedAuthoritiesService</param>
+                        <param>edu.ucsb.cs156.organic.config.SpaCsrfTokenRequestHandler</param>
+                        <param>edu.ucsb.cs156.organic.config.CsrfCookieFilter</param>
                     </excludedClasses>
                     <excludedTestClasses></excludedTestClasses>
                     <outputFormats>

--- a/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/organic/Interceptors/RoleUserInterceptor.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.organic.interceptors;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/organic/config/SecurityConfig.java
@@ -1,12 +1,18 @@
 package edu.ucsb.cs156.organic.config;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -23,16 +29,19 @@ import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMap
 import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.*;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * This class is used to configure Spring Security.
- * 
+ *
  * Among other things, this class is partially responsible for
  * the implementation of the ADMIN_GITHUB_LOGINS feature.
  */
@@ -60,10 +69,15 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+    http
             .exceptionHandling(handling -> handling.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
-            .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
-            .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+            .oauth2Login(
+                    oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
+            .csrf(csrf -> csrf
+                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+            .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class)
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
             .logout(logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutSuccessUrl("/"));
     return http.build();
   }
@@ -85,7 +99,7 @@ public class SecurityConfig {
 
           Map<String, Object> userAttributes = oauth2UserAuthority.getAttributes();
           log.trace("********** userAttributes={}", userAttributes);
-
+          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
           String githubLogin = (String) userAttributes.get("login");
           boolean userIsAdmin = updateAdmin(githubLogin);
           if (userIsAdmin) {
@@ -110,5 +124,55 @@ public class SecurityConfig {
       userRepository.save(user);
     }
     return result;
+  }
+}
+
+final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
+  private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+                     Supplier<CsrfToken> deferredCsrfToken) {
+    /*
+     * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection
+     * of
+     * the CsrfToken when it is rendered in the response body.
+     */
+    this.delegate.handle(request, response, deferredCsrfToken);
+  }
+
+  @Override
+  public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+    /*
+     * If the request contains a request header, use
+     * CsrfTokenRequestAttributeHandler
+     * to resolve the CsrfToken. This applies when a single-page application
+     * includes
+     * the header value automatically, which was obtained via a cookie containing
+     * the
+     * raw CsrfToken.
+     */
+    if (StringUtils.hasText(request.getHeader(csrfToken.getHeaderName()))) {
+      return super.resolveCsrfTokenValue(request, csrfToken);
+    }
+    /*
+     * In all other cases (e.g. if the request contains a request parameter), use
+     * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+     * when a server-side rendered form includes the _csrf request parameter as a
+     * hidden input.
+     */
+    return this.delegate.resolveCsrfTokenValue(request, csrfToken);
+  }
+}
+
+final class CsrfCookieFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+          throws ServletException, IOException {
+    CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
+    // Render the token value to a cookie by causing the deferred token to be loaded
+    csrfToken.getToken();
+    filterChain.doFilter(request, response);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -71,12 +71,7 @@ public abstract class ApiController {
     public static ObjectMapper mapperThatIgnoresMockitoMocks() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
-        mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
-            @Override
-            public boolean hasIgnoreMarker(final AnnotatedMember m) {
-                return super.hasIgnoreMarker(m) || m.getName().contains("Mockito");
-            }
-        });
+        mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector());
         return mapper;
     }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -30,7 +30,6 @@ import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDateTime;
 
-import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import java.util.Optional;

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendController.java
@@ -14,7 +14,7 @@ public class FrontendController {
   }
 
   @GetMapping("/csrf")
-  public ResponseEntity<String> csrf() {
+  public ResponseEntity<?> csrf() {
       return ResponseEntity.notFound().build();
   }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendController.java
@@ -14,7 +14,7 @@ public class FrontendController {
   }
 
   @GetMapping("/csrf")
-  public ResponseEntity<?> csrf() {
+  public ResponseEntity<String> csrf() {
       return ResponseEntity.notFound().build();
   }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/SchoolController.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.extern.slf4j.Slf4j;
-import javax.transaction.Transactional;
 import javax.validation.Valid;
 
 import java.time.LocalDateTime;

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
@@ -2,7 +2,7 @@ package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/edu/ucsb/cs156/organic/entities/School.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/School.java
@@ -2,7 +2,7 @@ package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Staff.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Staff.java
@@ -2,7 +2,7 @@ package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
@@ -2,7 +2,7 @@ package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 
 @Data

--- a/src/main/java/edu/ucsb/cs156/organic/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/User.java
@@ -2,7 +2,7 @@ package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;

--- a/src/main/java/edu/ucsb/cs156/organic/entities/UserEmail.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/UserEmail.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.organic.entities;
 
 import lombok.*;
-import javax.persistence.*;
+import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/java/edu/ucsb/cs156/organic/entities/jobs/Job.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/jobs/Job.java
@@ -6,7 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -2,8 +2,6 @@ spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
-
 spring.liquibase.url=${JDBC_DATABASE_URL}
 spring.liquibase.user=${JDBC_DATABASE_USERNAME}
 spring.liquibase.password=${JDBC_DATABASE_PASSWORD}

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -56,7 +56,6 @@ import edu.ucsb.cs156.organic.repositories.UserRepository;
 import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.organic.services.jobs.JobService;
 import edu.ucsb.cs156.organic.services.CurrentUserService;
-import liquibase.pro.packaged.W;
 import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 
@@ -738,7 +737,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         Map<String, String> responseMap = mapper.readValue(response.getResponse().getContentAsString(),
                 new TypeReference<Map<String, String>>() {
                 });
-        Map<String, String> expectedMap = Map.of("message", "Access is denied", "type",
+        Map<String, String> expectedMap = Map.of("message", "Access Denied", "type",
                 "AccessDeniedException");
         assertEquals(expectedMap, responseMap);
     }
@@ -909,7 +908,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         Map<String, String> responseMap = mapper.readValue(response.getResponse().getContentAsString(),
                 new TypeReference<Map<String, String>>() {
                 });
-        Map<String, String> expectedMap = Map.of("message", "Access is denied", "type",
+        Map<String, String> expectedMap = Map.of("message", "Access Denied", "type",
                 "AccessDeniedException");
         assertEquals(expectedMap, responseMap);
     }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/SchoolControllerTests.java
@@ -63,7 +63,6 @@ import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.organic.services.jobs.JobService;
 import edu.ucsb.cs156.organic.services.CurrentUserService;
-import liquibase.pro.packaged.W;
 import lombok.With;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/test/java/edu/ucsb/cs156/organic/services/GrantedAuthoritiesServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/services/GrantedAuthoritiesServiceTests.java
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -26,6 +27,9 @@ class GrantedAuthoritiesServiceTests {
 
   @MockBean
   UserRepository userRepository;
+
+  @MockBean
+  ClientRegistrationRepository clientRegistrationRepository;
 
   @Autowired
   GrantedAuthoritiesService grantedAuthoritiesService;

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
@@ -19,7 +19,6 @@ import java.sql.Timestamp; //importing this because we dont need instant we need
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.services.CurrentUserServiceImpl;
-import liquibase.pro.packaged.em;
 
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/TestConfig.java
@@ -1,12 +1,15 @@
 package edu.ucsb.cs156.organic.testconfig;
 
+import edu.ucsb.cs156.organic.config.SecurityConfig;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 import edu.ucsb.cs156.organic.services.CurrentUserService;
 import edu.ucsb.cs156.organic.services.GrantedAuthoritiesService;
+import org.springframework.context.annotation.Import;
 
 @TestConfiguration
+@Import(SecurityConfig.class)
 public class TestConfig {
 
     @Bean


### PR DESCRIPTION
In this PR, I upgraded the backend to Spring Boot 3.2.1. I used the team03 starter [as a reference](https://github.com/ucsb-cs156-f24/STARTER-team03/pull/13), and retooled the SecurityConfig class to match. I then hammered out the import statement changes with some help from Intellij IDEA, before ensuring that the tests passed by making necessary changes there. I mostly did my best to follow the model, but I did try to sort out some the import statement jumble by ignoring changes that appeared to move import statements around.

To end the final missing line coverage, I tested the ensuing test and realized there were no Mockito markers in the mapping. As a result, I removed the offending code from the project without having to modify the tests, as it was unused.

I had 100% code coverage and 100% mutations killed locally.
Changes are visible at [https://proj-organic-daniel-dev.dokku-12.cs.ucsb.edu/](https://proj-organic-daniel-dev.dokku-12.cs.ucsb.edu/)

Closes #9 