### PR TITLE
Add School Dropdown

### DIFF
--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -5,7 +5,7 @@ import {useFormContext} from "react-hook-form";
 //This is roughly based on the schedule dropdown from Courses, available
 //at https://github.com/ucsb-cs156/proj-courses/blob/main/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
 
-const SchoolDropdown = ({schools, testId}) => {
+const SchoolDropdown = ({schools = [], testId}) => {
     const {
         register,
         formState: {errors}

--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Form } from "react-bootstrap";
+import {useFormContext} from "react-hook-form";
+
+//This is roughly based on the schedule dropdown from Courses, available
+//at https://github.com/ucsb-cs156/proj-courses/blob/main/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
+
+const SchoolDropdown = ({schools, testId}) => {
+    const {
+        register,
+        formState: {errors}
+    } = useFormContext();
+
+    return (<Form.Group>
+        <Form.Label htmlFor="school">School</Form.Label>
+        <Form.Control data-testid={`${testId}-schooldropdown`} id="school"  as="select"
+          isInvalid={Boolean(errors.school)}
+          {...register("school", {required: true, minLength: 2})}
+        >
+            <option value=""></option>
+            {schools.map(function (object, i) {
+                const key = `${testId}-option-${i}`
+                console.log("This ran");
+                return(
+                    <option key={key} data-testid={key} value={object.abbrev}>
+                        {object.name}
+                    </option>
+                );
+            })}
+        </Form.Control>
+        <Form.Control.Feedback type="invalid">
+            {errors.school && 'School is required. '}
+        </Form.Control.Feedback>
+    </Form.Group>);
+}
+
+export default SchoolDropdown;

--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -2,9 +2,6 @@ import React from "react";
 import { Form } from "react-bootstrap";
 import {useFormContext} from "react-hook-form";
 
-//This is roughly based on the schedule dropdown from Courses, available
-//at https://github.com/ucsb-cs156/proj-courses/blob/main/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
-
 const SchoolDropdown = ({schools = [], testId}) => {
     const {
         register,

--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -21,7 +21,7 @@ const SchoolDropdown = ({schools, testId}) => {
             {schools.map(function (object, i) {
                 const key = `${testId}-option-${i}`
                 return(
-                    <option key={key} data-testid={key} value={object.abbrev}>
+                    <option key={key} data-testid={key} value={object.name}>
                         {object.name}
                     </option>
                 );

--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -13,14 +13,13 @@ const SchoolDropdown = ({schools, testId}) => {
 
     return (<Form.Group>
         <Form.Label htmlFor="school">School</Form.Label>
-        <Form.Control data-testid={`${testId}-schooldropdown`} id="school"  as="select"
+        <Form.Control data-testid={`${testId}-school`} id="school"  as="select"
           isInvalid={Boolean(errors.school)}
           {...register("school", {required: true, minLength: 2})}
         >
             <option value=""></option>
             {schools.map(function (object, i) {
                 const key = `${testId}-option-${i}`
-                console.log("This ran");
                 return(
                     <option key={key} data-testid={key} value={object.abbrev}>
                         {object.name}

--- a/frontend/src/stories/components/Courses/SchoolDropdown.stories.js
+++ b/frontend/src/stories/components/Courses/SchoolDropdown.stories.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import SchoolDropdown from "../../../main/components/Courses/SchoolDropdown";
+import {schoolsFixtures} from "../../../fixtures/schoolsFixtures";
+import {Button, Form} from "react-bootstrap";
+import {FormProvider, useForm} from "react-hook-form";
+
+export default {
+    title: "components/Courses/SchoolDropdown",
+    component: SchoolDropdown
+}
+
+const Template = (args) => {
+    return(
+        <ModelForm {...args} />
+    );
+}
+
+export const Filled = Template.bind({});
+
+Filled.args={
+    schools: schoolsFixtures.threeSchools,
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data);
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+}
+
+export const Preselected = Template.bind({});
+
+Preselected.args={
+    schools: schoolsFixtures.threeSchools,
+    initialContents: {"school":"ucsb"},
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data);
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+}
+
+
+const ModelForm = ({initialContents, submitAction, schools}) =>{
+    const formState = useForm({defaultValues: initialContents || {},});
+    const {
+        handleSubmit
+    } = formState;
+    return(
+        <FormProvider {...formState}>
+            <Form onSubmit={handleSubmit(submitAction)}>
+                <SchoolDropdown schools={schools} testId="SchoolDropdownExample" />
+                <Button
+                    type="submit"
+                    data-testid="SchoolDropdownExample-submit"
+                >
+                    Submit
+                </Button>
+            </Form>
+        </FormProvider>
+    )
+}
+

--- a/frontend/src/stories/components/Courses/SchoolDropdown.stories.js
+++ b/frontend/src/stories/components/Courses/SchoolDropdown.stories.js
@@ -29,7 +29,7 @@ export const Preselected = Template.bind({});
 
 Preselected.args={
     schools: schoolsFixtures.threeSchools,
-    initialContents: {"school":"ucsb"},
+    initialContents: {"school":"UC Santa Barbara"},
     submitAction: (data) => {
         console.log("Submit was clicked with data: ", data);
         window.alert("Submit was clicked with data: " + JSON.stringify(data));

--- a/frontend/src/tests/components/Courses/SchoolDropdown.test.js
+++ b/frontend/src/tests/components/Courses/SchoolDropdown.test.js
@@ -52,6 +52,10 @@ describe("Tests as a standalone school dropdown", () =>{
         await screen.findByText(/School/);
 
         expect(screen.getByTestId("SchoolDropdownExample-school")).toBeInTheDocument();
+
+        const school1 = screen.queryByTestId("SchoolDropdownExample-option-0");
+
+        expect(school1).not.toBeInTheDocument();
     })
     test("Won't let you submit blank", async () => {
         render(

--- a/frontend/src/tests/components/Courses/SchoolDropdown.test.js
+++ b/frontend/src/tests/components/Courses/SchoolDropdown.test.js
@@ -1,0 +1,78 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import {FormProvider, useForm} from "react-hook-form";
+import {Button, Form} from "react-bootstrap";
+import SchoolDropdown from "../../../main/components/Courses/SchoolDropdown";
+import React from "react";
+import {schoolsFixtures} from "../../../fixtures/schoolsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+const ModelForm = ({schools}) =>{
+    const formState = useForm({defaultValues: {},});
+    const {
+        handleSubmit
+    } = formState;
+
+    const onSubmit = (data) => {
+        /*
+        This is here so the form doesn't get angry about not having a submit,
+        as we want to test the dropdown, not the mocked form
+         */
+    }
+
+    return(
+        <FormProvider {...formState}>
+            <Form onSubmit={handleSubmit(onSubmit)}>
+                <SchoolDropdown schools={schools} testId="SchoolDropdownExample" />
+                <Button
+                    type="submit"
+                    data-testid="SchoolDropdownExample-submit"
+                >
+                    Submit
+                </Button>
+            </Form>
+        </FormProvider>
+    )
+}
+
+
+describe("Tests as a standalone school dropdown", () =>{
+
+    test("Renders 3 schools correctly", async () => {
+        render(
+            <ModelForm schools={schoolsFixtures.threeSchools}/>
+        )
+
+        await screen.findByText(/School/);
+
+        const school1 = screen.getByTestId("SchoolDropdownExample-option-0");
+        const school2 = screen.getByTestId("SchoolDropdownExample-option-1");
+        const school3 = screen.getByTestId("SchoolDropdownExample-option-2");
+
+        expect(screen.getByTestId("SchoolDropdownExample-school")).toBeInTheDocument();
+
+        expect(school1).toHaveTextContent("UC Santa Barbara");
+        expect(school2).toHaveTextContent("University of Minnesota");
+        expect(school3).toHaveTextContent("UC San Diego");
+    })
+
+    test("Validation work correctly", async () => {
+        render(
+            <ModelForm schools={schoolsFixtures.threeSchools}/>
+        )
+
+        await screen.findByText(/School/);
+
+        expect(screen.getByTestId("SchoolDropdownExample-school")).toBeInTheDocument();
+
+        const submit = screen.getByTestId(/SchoolDropdownExample-submit/);
+        fireEvent.click(submit);
+
+        await screen.findByText(/School is required/);
+    })
+})

--- a/frontend/src/tests/components/Courses/SchoolDropdown.test.js
+++ b/frontend/src/tests/components/Courses/SchoolDropdown.test.js
@@ -18,7 +18,7 @@ const ModelForm = ({schools}) =>{
         handleSubmit
     } = formState;
 
-    const onSubmit = (data) => {
+    const onSubmit = () => {
         /*
         This is here so the form doesn't get angry about not having a submit,
         as we want to test the dropdown, not the mocked form

--- a/frontend/src/tests/components/Courses/SchoolDropdown.test.js
+++ b/frontend/src/tests/components/Courses/SchoolDropdown.test.js
@@ -41,7 +41,31 @@ const ModelForm = ({schools}) =>{
 }
 
 
+
 describe("Tests as a standalone school dropdown", () =>{
+
+    test("Works without schools passed in", async () => {
+        render(
+            <ModelForm />
+        )
+
+        await screen.findByText(/School/);
+
+        expect(screen.getByTestId("SchoolDropdownExample-school")).toBeInTheDocument();
+    })
+    test("Won't let you submit blank", async () => {
+        render(
+            <ModelForm />
+        )
+        await screen.findByText(/School/);
+
+        expect(screen.getByTestId("SchoolDropdownExample-school")).toBeInTheDocument();
+
+        const submit = screen.getByTestId(/SchoolDropdownExample-submit/);
+        fireEvent.click(submit);
+
+        await screen.findByText(/School is required/);
+    })
 
     test("Renders 3 schools correctly", async () => {
         render(


### PR DESCRIPTION
In this PR, I added a standalone school dropdown that can be used in other forms to select which school the course is associated with. Passed in are the testid and schools to be displayed. 

I completed this using ReactJS's built-in useFormContext() feature rather than localstorage so that I could include validation and register it as a form field.

Since these changes are not visible on the site yet, here is the link to them on [storybook](https://ucsb-cs156-s24.github.io/proj-organic-s24-5pm-4/prs/18/storybook/?path=/story/components-courses-schooldropdown--filled).

Closes #11 (offshoot of #5)

Notably, this is very different than the examples of dropdowns I was provided ([see here](https://github.com/ucsb-cs156/proj-courses/blob/main/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js)) because I believe this way has better form integration.