### PR TITLE
Implementation of Partial Mutation Pitests in pom.xml 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This repo has support for partial pitest runs
 For example, to run pitest on just one class, use:
 
 ```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.RestaurantsController
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.JobsController
 ```
 
 To run pitest on just one package, use:
 
 ```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.*
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.\*
 ```
 
 To run full mutation test coverage, as usual, use:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@
 
 # W24 Production Deployments
 
+# Partial Test Commands
+Add After - mvn pitest:mutationCoverage
+
+For tests on one class:
+
+```
+
+ -DtargetClasses=edu.ucsb.cs156.organic.controllers.CLASS_NAME
+
+```
+
+You must use the class name, not the file name.
+
+For tests on a package:
+```
+
+ -DtargetClasses=edu.ucsb.cs156organic.controllers.*
+ 
+```
 
 | Team | Link       | 
 |------|------------|

--- a/README.md
+++ b/README.md
@@ -9,24 +9,26 @@
 
 # W24 Production Deployments
 
-# Partial Test Commands
-Add After - mvn pitest:mutationCoverage
+## Partial pitest runs
 
-For tests on one class:
+This repo has support for partial pitest runs
 
-```
-
- -DtargetClasses=edu.ucsb.cs156.organic.controllers.CLASS_NAME
+For example, to run pitest on just one class, use:
 
 ```
-
-You must use the class name, not the file name.
-
-For tests on a package:
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.RestaurantsController
 ```
 
- -DtargetClasses=edu.ucsb.cs156organic.controllers.*
- 
+To run pitest on just one package, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.*
+```
+
+To run full mutation test coverage, as usual, use:
+
+```
+mvn pitest:mutationCoverage
 ```
 
 | Team | Link       | 

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
+    
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -17,6 +18,9 @@
     <description>A tool for managing github organizations for courses</description>
     <properties>
         <java.version>17</java.version>
+        <app.package>edu.ucsb.cs156.organic</app.package>
+        <app.packagePath>edu/ucsb/cs156/organic</app.packagePath>
+        <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     </properties>
     <dependencies>
         <dependency>
@@ -241,7 +245,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                        <param>edu.ucsb.cs156.*</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>


### PR DESCRIPTION
Closes #19 

Implemented the ability to do partial Pitests with the commands provided below. Only some simple edits to pom.xml and edits to readme for the main commands. 

For tests on one class do:
mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.CLASS_NAME

You must use the class name, not the file name.

For tests on a package:

mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.*


Output after running --- : mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.StudentsController

![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/92130195/7128f7c8-97f8-449c-9648-eb510f237370)

Output after running ---:mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.organic.controllers.*
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/92130195/4a15c869-b78f-42e3-ba5a-64d5b41a07df)
