### PR TITLE
Refactor the Course Form

### DIFF
--- a/frontend/src/main/components/Courses/CoursesForm.js
+++ b/frontend/src/main/components/Courses/CoursesForm.js
@@ -1,21 +1,33 @@
 import { Button, Form, Row, Col } from 'react-bootstrap';
-import { useForm } from 'react-hook-form'
+import {FormProvider, useForm} from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { enableEndDateValidation } from './dateValidation'; // Import the JavaScript file
 import React, { useEffect } from 'react';
+import {useBackend} from "../../utils/useBackend";
+import SchoolDropdown from "./SchoolDropdown";
 
 function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     useEffect(() => {
         enableEndDateValidation(); // Call the function to enable end date validation
     },); // Run only once after component mounts
     // Stryker disable all
+    const formState = useForm({defaultValues:initialContents || {},})
+
     const {
         register,
         formState: { errors },
         handleSubmit,
-    } = useForm(
-        { defaultValues: initialContents || {}, }
-    );
+    } = formState;
+
+    const { data: schools, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/schools/all"],
+            // Stryker disable next-line all : GET is the default
+            { method: "GET", url: "/api/schools/all" },
+            []
+        );
+
 
     const navigate = useNavigate();
     
@@ -25,148 +37,138 @@ function CoursesForm({ initialContents, submitAction, buttonLabel = "Create" }) 
     const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
     
     return (
+        <FormProvider {...formState}>
+            <Form onSubmit={handleSubmit(submitAction)}>
 
-        <Form onSubmit={handleSubmit(submitAction)}>
 
+                <Row>
 
-            <Row>
+                    {initialContents && (
+                        <Col>
+                            <Form.Group className="mb-3" >
+                                <Form.Label htmlFor="id">Id</Form.Label>
+                                <Form.Control
+                                    data-testid="CoursesForm-id"
+                                    id="id"
+                                    type="text"
+                                    {...register("id")}
+                                    value={initialContents.id}
+                                    disabled
+                                />
+                            </Form.Group>
+                        </Col>
+                    )}
 
-                {initialContents && (
                     <Col>
                         <Form.Group className="mb-3" >
-                            <Form.Label htmlFor="id">Id</Form.Label>
+                            <Form.Label htmlFor="name">Name</Form.Label>
                             <Form.Control
-                                data-testid="CoursesForm-id"
-                                id="id"
+                                data-testid="CoursesForm-name"
+                                id="name"
                                 type="text"
-                                {...register("id")}
-                                value={initialContents.id}
-                                disabled
+                                isInvalid={Boolean(errors.name)}
+                                {...register("name", { required: true })}
                             />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.name && 'Name is required. '}
+                            </Form.Control.Feedback>
                         </Form.Group>
                     </Col>
-                )}
+                </Row>
 
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="name">Name</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-name"
-                            id="name"
-                            type="text"
-                            isInvalid={Boolean(errors.name)}
-                            {...register("name", { required: true })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.name && 'Name is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <SchoolDropdown testId="CoursesForm" schools={schools}/>
+                        </Form.Group>
+                    </Col>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="term">Term</Form.Label>
+                            <Form.Control
+                                data-testid="CoursesForm-term"
+                                id="term"
+                                type="text"
+                                isInvalid={Boolean(errors.term)}
+                                {...register("term", { required: true })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.term && 'Term is required. '}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
 
-            <Row>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="school">School</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-school"
-                            id="school"
-                            type="text"
-                            isInvalid={Boolean(errors.school)}
-                            {...register("school", { required: true })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.school && 'School is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="term">Term</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-term"
-                            id="term"
-                            type="text"
-                            isInvalid={Boolean(errors.term)}
-                            {...register("term", { required: true })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.term && 'Term is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="startDate">StartDate(iso format)</Form.Label>
+                            <Form.Control
+                                data-testid="CoursesForm-startDate"
+                                id="startDate"
+                                type="datetime-local"
+                                isInvalid={Boolean(errors.startDate)}
+                                {...register("startDate", { required: true, pattern: isodate_regex })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.startDate && 'StartDate date is required. '}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="">EndDate(iso format)</Form.Label>
+                            <Form.Control
+                                data-testid="CoursesForm-endDate"
+                                id="endDate"
+                                type="datetime-local"
+                                isInvalid={Boolean(errors.endDate)}
+                                {...register("endDate", {required: true, pattern: isodate_regex })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.endDate && 'EndDate date is required. '}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
 
-            <Row>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="startDate">StartDate(iso format)</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-startDate"
-                            id="startDate"
-                            type="datetime-local"
-                            isInvalid={Boolean(errors.startDate)}
-                            {...register("startDate", { required: true, pattern: isodate_regex })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.startDate && 'StartDate date is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="">EndDate(iso format)</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-endDate"
-                            id="endDate"
-                            type="datetime-local"
-                            isInvalid={Boolean(errors.endDate)}
-                            {...register("endDate", {required: true, pattern: isodate_regex })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.endDate && 'EndDate date is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="githubOrg">GithubOrg</Form.Label>
+                            <Form.Control
+                                data-testid="CoursesForm-githubOrg"
+                                id="githubOrg"
+                                type="text"
+                                isInvalid={Boolean(errors.githubOrg)}
+                                {...register("githubOrg", { required: true })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.githubOrg && 'GithubOrg is required. '}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
 
-            <Row>
-                <Col>
-                    <Form.Group className="mb-3" >
-                        <Form.Label htmlFor="githubOrg">GithubOrg</Form.Label>
-                        <Form.Control
-                            data-testid="CoursesForm-githubOrg"
-                            id="githubOrg"
-                            type="text"
-                            isInvalid={Boolean(errors.githubOrg)}
-                            {...register("githubOrg", { required: true })}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {errors.githubOrg && 'GithubOrg is required. '}
-                        </Form.Control.Feedback>
-                    </Form.Group>
-                </Col>
-            </Row>
-
-            <Row>
-                <Col>
-                    <Button
-                        type="submit"
-                        data-testid="CoursesForm-submit"
-                    >
-                        {buttonLabel}
-                    </Button>
-                    <Button
-                        variant="Secondary"
-                        onClick={() => navigate(-1)}
-                        data-testid="CoursesForm-cancel"
-                    >
-                        Cancel
-                    </Button>
-                </Col>
-            </Row>
-        </Form>
-
+                <Row>
+                    <Col>
+                        <Button
+                            type="submit"
+                            data-testid="CoursesForm-submit"
+                        >
+                            {buttonLabel}
+                        </Button>
+                        <Button
+                            variant="Secondary"
+                            onClick={() => navigate(-1)}
+                            data-testid="CoursesForm-cancel"
+                        >
+                            Cancel
+                        </Button>
+                    </Col>
+                </Row>
+            </Form>
+        </FormProvider>
     )
 }
 

--- a/frontend/src/stories/components/Courses/CoursesForm.stories.js
+++ b/frontend/src/stories/components/Courses/CoursesForm.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import CoursesForm from 'main/components/Courses/CoursesForm';
 import { coursesFixtures } from 'fixtures/coursesFixtures';
+import {rest} from "msw";
+import {schoolsFixtures} from "../../../fixtures/schoolsFixtures";
 
 export default {
     title: 'components/Courses/CoursesForm',
@@ -24,6 +26,14 @@ Create.args = {
    }
 };
 
+Create.parameters ={
+    msw:[
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
+        })
+    ]
+}
+
 export const Update = Template.bind({});
 
 Update.args = {
@@ -34,3 +44,11 @@ Update.args = {
         window.alert("Submit was clicked with data: " + JSON.stringify(data));
    }
 };
+
+Update.parameters ={
+    msw:[
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
+        })
+    ]
+}

--- a/frontend/src/stories/pages/CourseIndexPage.stories.js
+++ b/frontend/src/stories/pages/CourseIndexPage.stories.js
@@ -5,6 +5,7 @@ import { coursesFixtures } from "fixtures/coursesFixtures";
 import { rest } from "msw";
 
 import CourseIndexPage from "main/pages/CourseIndexPage";
+import {schoolsFixtures} from "../../fixtures/schoolsFixtures";
 
 export default {
     title: 'pages/Course/CourseIndexPage',
@@ -22,6 +23,9 @@ Empty.parameters = {
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
+        }),
         rest.get('/api/courses/all', (_req, res, ctx) => {
             return res(ctx.json(coursesFixtures.threeCourses));
         }),
@@ -29,6 +33,7 @@ Empty.parameters = {
             window.alert("DELETE: " + JSON.stringify(req.url));
             return res(ctx.status(200),ctx.json({}));
         }),
+
     ]
 }
 
@@ -41,6 +46,9 @@ ThreeItemsInstructorUser.parameters = {
         }),
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
         }),
         rest.get('/api/courses/all', (_req, res, ctx) => {
             return res(ctx.json(coursesFixtures.threeCourses));
@@ -61,6 +69,9 @@ ThreeItemsAdminUser.parameters = {
         }),
         rest.get('/api/systemInfo', (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
         }),
         rest.get('/api/courses/all', (_req, res, ctx) => {
             return res(ctx.json(coursesFixtures.threeCourses));

--- a/frontend/src/stories/pages/CoursesCreatePage.stories.js
+++ b/frontend/src/stories/pages/CoursesCreatePage.stories.js
@@ -4,6 +4,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { rest } from "msw";
 
 import CoursesCreatePage from "main/pages/CoursesCreatePage";
+import {schoolsFixtures} from "../../fixtures/schoolsFixtures";
 
 export default {
     title: 'pages/Courses/CoursesCreatePage',
@@ -24,6 +25,9 @@ Default.parameters = {
         rest.post('/api/courses/post', (req, res, ctx) => {
             window.alert("POST: " + JSON.stringify(req.url));
             return res(ctx.status(200),ctx.json({}));
+        }),
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
         }),
     ]
 }

--- a/frontend/src/stories/pages/CoursesEditPage.stories.js
+++ b/frontend/src/stories/pages/CoursesEditPage.stories.js
@@ -6,6 +6,7 @@ import { coursesFixtures } from 'fixtures/coursesFixtures';
 import { rest } from "msw";
 
 import CoursesEditPage from 'main/pages/CoursesEditPage';
+import {schoolsFixtures} from "../../fixtures/schoolsFixtures";
 
 export default {
     title: 'pages/CoursesEditPage',
@@ -25,6 +26,9 @@ Default.parameters = {
         }),
         rest.get('/api/courses', (_req, res, ctx) => {
             return res(ctx.json(coursesFixtures.threeCourses[0]));
+        }),
+        rest.get('/api/schools/all', (_req, res, ctx) => {
+            return res(ctx.json(schoolsFixtures.threeSchools));
         }),
         rest.put('/api/courses', async (req, res, ctx) => {
             var reqBody = await req.text();

--- a/frontend/src/tests/pages/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/CoursesCreatePage.test.js
@@ -8,6 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import {schoolsFixtures} from "../../fixtures/schoolsFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -39,6 +40,7 @@ describe("CourseCreatePage tests", () => {
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
     });
 
     const queryClient = new QueryClient();
@@ -58,7 +60,7 @@ describe("CourseCreatePage tests", () => {
         const course = {
             id: 1,
             name: "CS156",
-            school: "UCSB",
+            school: "UC Santa Barbara",
             term: "F23",
             startDate: "2023-09-24T12:00:00",
             endDate: "2023-12-15T12:00:00",
@@ -88,7 +90,7 @@ describe("CourseCreatePage tests", () => {
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'CS156' } });
-        fireEvent.change(schoolField, { target: { value: 'UCSB' } });
+        fireEvent.change(schoolField, { target: { value: 'UC Santa Barbara' } });
         fireEvent.change(termField, { target: { value: 'F23' } });
         fireEvent.change(startDateField, { target: { value: '2023-09-24T12:00:00' } });
         fireEvent.change(endDateField, { target: { value: '2023-12-15T12:00:00' } });
@@ -103,7 +105,7 @@ describe("CourseCreatePage tests", () => {
         expect(axiosMock.history.post[0].params).toEqual(
             {
                 "name": "CS156",
-                "school": "UCSB",
+                "school": "UC Santa Barbara",
                 "term": "F23",
                 "startDate": "2023-09-24T12:00",
                 "endDate": "2023-12-15T12:00",

--- a/frontend/src/tests/pages/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/CoursesEditPage.test.js
@@ -8,6 +8,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import mockConsole from "jest-mock-console";
+import {schoolsFixtures} from "../../fixtures/schoolsFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -48,6 +49,7 @@ describe("CoursesEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/schools/all").timeout();
             axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).timeout();
         });
 
@@ -78,10 +80,11 @@ describe("CoursesEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
             axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 name: "CS 156",
-                school: "UCSB",
+                school: "UC Santa Barbara",
                 term: "f23",
                 startDate: "2023-09-29T00:00",
                 endDate: "2023-12-15T00:00",
@@ -90,7 +93,7 @@ describe("CoursesEditPage tests", () => {
             axiosMock.onPut('/api/courses/update').reply(200, {
                 id: "17",
                 name: "CS 148",
-                school: "UCSB",
+                school: "UC Santa Barbara",
                 term: "w23",
                 startDate: "2024-01-10T00:00",
                 endDate: "2023-03-12T00:00",
@@ -132,7 +135,7 @@ describe("CoursesEditPage tests", () => {
 
             expect(idField).toHaveValue("17");
             expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UCSB");
+            expect(schoolField).toHaveValue("UC Santa Barbara");
             expect(termField).toHaveValue("f23");
             expect(startField).toHaveValue("2023-09-29T00:00");
             expect(endField).toHaveValue("2023-12-15T00:00");
@@ -163,7 +166,7 @@ describe("CoursesEditPage tests", () => {
 
             expect(idField).toHaveValue("17");
             expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UCSB");
+            expect(schoolField).toHaveValue("UC Santa Barbara");
             expect(termField).toHaveValue("f23");
             expect(startField).toHaveValue("2023-09-29T00:00");
             expect(endField).toHaveValue("2023-12-15T00:00");
@@ -171,7 +174,7 @@ describe("CoursesEditPage tests", () => {
             expect(submitButton).toBeInTheDocument();
 
             fireEvent.change(nameField, { target: { value: "CS 148" } })
-            fireEvent.change(schoolField, { target: { value: "UCSB" } })
+            fireEvent.change(schoolField, { target: { value: "University of Minnesota" } })
             fireEvent.change(termField, { target: { value: "w23" } })
             fireEvent.change(startField, { target: { value: "2024-01-10T00:00" } })
             fireEvent.change(endField, { target: { value: "2023-03-12T00:00" } })
@@ -184,7 +187,7 @@ describe("CoursesEditPage tests", () => {
             expect(mockNavigate).toBeCalledWith({ "to": "/courses" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", school: "UCSB", term: "w23", githubOrg: "ucsb-cs156-w23" });
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", school: "University of Minnesota", term: "w23", githubOrg: "ucsb-cs156-w23" });
 
         });
 


### PR DESCRIPTION
### This should be merged after #18

In this PR, I used my work in #18 to refactor the course form, replacing the text entry for schools with a dropdown. I made a design choice that the value is the full school name, rather than linking it to abbreviation on the backend, as it would increase complexity for the table class on the frontend. I then updated the tests for CreateCoursePage, CourseForm, and CourseEditPage.

These changes are visible at https://proj-organic-daniel-dev.dokku-12.cs.ucsb.edu

Closes #23

Screenshots:
Creating:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/fb6e7513-c3ea-472f-a1c9-8528a4226d0f)

Editing:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/6ddb2864-769e-481b-88a6-29e27009f45b)

Linked validation:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/acaf2c0e-f95d-49d4-9576-0d5cd0094052)
