### PR TITLE
Make Courses Storybooks Consistent

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,7 +14,7 @@ import AdminJobsPage from "main/pages/AdminJobsPage";
 import SchoolIndexPage from "main/pages/SchoolIndexPage";
 
 import CoursesCreatePage from "main/pages/CoursesCreatePage";
-import CourseIndexPage from "main/pages/CourseIndexPage";
+import CoursesIndexPage from "main/pages/CoursesIndexPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import NotFoundPage from "main/pages/NotFoundPage";
@@ -33,14 +33,14 @@ function App() {
   const userRoutes = hasRole(currentUser, "ROLE_USER") ? (
     <>
       <Route path="/profile" element={<ProfilePage />} />
-      <Route path="/courses" element={<CourseIndexPage />} />
+      <Route path="/courses" element={<CoursesIndexPage />} />
     </>
   ) : null;
 
   const courseRoutes = (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_INSTRUCTOR")) ? (
     <>
       <Route path="/courses/create" element={<CoursesCreatePage />} />
-      <Route path="/courses" element={<CourseIndexPage />} />
+      <Route path="/courses" element={<CoursesIndexPage />} />
       <Route path="/courses/edit/:id" element={<CoursesEditPage />} />
     </>
   ) : null;

--- a/frontend/src/main/pages/CoursesIndexPage.js
+++ b/frontend/src/main/pages/CoursesIndexPage.js
@@ -5,7 +5,7 @@ import CoursesTable from 'main/components/Courses/CoursesTable';
 import { Button } from 'react-bootstrap';
 import { useCurrentUser, hasRole} from 'main/utils/currentUser';
 
-export default function CourseIndexPage() {
+export default function CoursesIndexPage() {
 
   const { data: currentUser } = useCurrentUser();
   const createButton = () => {  

--- a/frontend/src/stories/pages/CourseIndexPage.stories.js
+++ b/frontend/src/stories/pages/CourseIndexPage.stories.js
@@ -7,7 +7,7 @@ import { rest } from "msw";
 import CourseIndexPage from "main/pages/CourseIndexPage";
 
 export default {
-    title: 'pages/Course/CourseIndexPage',
+    title: 'pages/Courses/CourseIndexPage',
     component: CourseIndexPage
 };
 

--- a/frontend/src/stories/pages/CoursesEditPage.stories.js
+++ b/frontend/src/stories/pages/CoursesEditPage.stories.js
@@ -8,7 +8,7 @@ import { rest } from "msw";
 import CoursesEditPage from 'main/pages/CoursesEditPage';
 
 export default {
-    title: 'pages/CoursesEditPage',
+    title: 'pages/Courses/CoursesEditPage',
     component: CoursesEditPage
 };
 

--- a/frontend/src/stories/pages/CoursesIndexPage.stories.js
+++ b/frontend/src/stories/pages/CoursesIndexPage.stories.js
@@ -4,14 +4,14 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { coursesFixtures } from "fixtures/coursesFixtures";
 import { rest } from "msw";
 
-import CourseIndexPage from "main/pages/CourseIndexPage";
+import CoursesIndexPage from "main/pages/CoursesIndexPage";
 
 export default {
-    title: 'pages/Courses/CourseIndexPage',
-    component: CourseIndexPage
+    title: 'pages/Courses/CoursesIndexPage',
+    component: CoursesIndexPage
 };
 
-const Template = () => <CourseIndexPage storybook={true}/>;
+const Template = () => <CoursesIndexPage storybook={true}/>;
 
 export const Empty = Template.bind({});
 Empty.parameters = {

--- a/frontend/src/tests/pages/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/CoursesIndexPage.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import CourseIndexPage from "main/pages/CourseIndexPage";
+import CoursesIndexPage from "main/pages/CoursesIndexPage";
 
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
@@ -22,7 +22,7 @@ jest.mock('react-toastify', () => {
     };
 });
 
-describe("CourseIndexPage tests", () => {
+describe("CoursesIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -59,7 +59,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -83,7 +83,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -107,7 +107,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -128,7 +128,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -150,7 +150,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -173,7 +173,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -197,7 +197,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -221,7 +221,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -253,7 +253,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -284,7 +284,7 @@ describe("CourseIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <CourseIndexPage />
+                    <CoursesIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );


### PR DESCRIPTION
In this PR, I made the courses storybooks show up consistently -- previously, some were in a Course folder, others in Courses, and one out in the menu. I made them all show up in the same courses folder. 

I don't really expect points for this one, it just bothered me and is unrelated to any issue.

Photo of changes:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/8bc9c07a-7ad0-4464-9e13-fec37ce4fedc)

Additionally, for consistency's sake, I renamed CourseIndexPages to Course(s)IndexPage to be more consistent, and refactored all of the references via Intellij IDEA. These changes are not visible, and so have no screenshots.
