### PR TITLE
Add StudentForm for Uploading Rosters

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
-        "@testing-library/user-event": "^12.8.3",
+        "@testing-library/user-event": "^14.5.2",
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "bootstrap": "^5.0.0-beta3",
@@ -11507,14 +11507,11 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.8.3",
+    "@testing-library/user-event": "^14.5.2",
     "axios": "^0.21.1",
     "babel-loader": "8.1.0",
     "bootstrap": "^5.0.0-beta3",

--- a/frontend/src/main/components/Students/StudentsForm.js
+++ b/frontend/src/main/components/Students/StudentsForm.js
@@ -1,0 +1,40 @@
+import {useForm} from "react-hook-form";
+import {Button, Form, Row} from "react-bootstrap";
+import React from "react";
+
+function StudentsForm({submitAction}){
+    const {
+        register,
+        formState: {errors},
+        handleSubmit
+    } = useForm()
+
+    return(
+        <Form onSubmit={handleSubmit(submitAction)}>
+            <Row>
+                <Form.Group className="mb-2">
+                    <Form.Label htmlFor="upload">Upload Student Roster</Form.Label>
+                    <Form.Control data-testid="StudentsForm-upload"
+                                  id="upload"
+                                  type="file"
+                                  accept=".csv"
+                                  isInvalid={Boolean(errors.upload)}
+                        {...register("upload", {required:true})} />
+                </Form.Group>
+                <Form.Control.Feedback type="invalid">
+                    {errors.upload && 'Roster is required. '}
+                </Form.Control.Feedback>
+            </Row>
+            <Row>
+                <Button type="submit"
+                        data-testid="StudentsForm-submit"
+                        className="mb-3"
+                >
+                    Upload
+                </Button>
+            </Row>
+        </Form>
+    );
+}
+
+export default StudentsForm

--- a/frontend/src/main/components/Students/StudentsForm.js
+++ b/frontend/src/main/components/Students/StudentsForm.js
@@ -20,10 +20,10 @@ function StudentsForm({submitAction}){
                                   accept=".csv"
                                   isInvalid={Boolean(errors.upload)}
                         {...register("upload", {required:true})} />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.upload && 'Roster is required. '}
+                    </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Control.Feedback type="invalid">
-                    {errors.upload && 'Roster is required. '}
-                </Form.Control.Feedback>
             </Row>
             <Row>
                 <Button type="submit"

--- a/frontend/src/stories/components/Students/StudentsForm.stories.js
+++ b/frontend/src/stories/components/Students/StudentsForm.stories.js
@@ -1,0 +1,22 @@
+import StudentsForm from "../../../main/components/Students/StudentsForm";
+
+
+export default{
+    title: "components/Students/StudentsForm",
+    component: StudentsForm
+}
+
+const Template = (args) => {
+    return(
+        <StudentsForm {...args} />
+    );
+}
+
+export const Default = Template.bind({});
+
+Default.args={
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data);
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+}

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,0 +1,40 @@
+import {render, fireEvent, screen} from "@testing-library/react";
+import StudentsForm from "../../../main/components/Students/StudentsForm";
+import userEvent from "@testing-library/user-event";
+
+describe("StudentsForm Tests", () => {
+    /*
+    Thank you stack overflow for this tip
+    https://stackoverflow.com/questions/61104842/react-testing-library-how
+    -to-simulate-file-upload-to-a-input-type-file-e
+    Told me how to upload a file, and the simulation of comparing it on lines 32 and 39, and 40
+    */
+    const file = new File(['there'], 'roster.csv', {type: '.csv'})
+    test("Required fires when there's no input", async () => {
+        render(
+            <StudentsForm/>
+        );
+        await screen.findByTestId("StudentsForm-submit");
+
+        const submitButton = screen.getByTestId("StudentsForm-submit");
+        fireEvent.click(submitButton);
+        await screen.findByText(/Roster is required/);
+    });
+
+    test("No errors on good submit", async () => {
+        render(
+            <StudentsForm/>
+        );
+        await screen.findByTestId("StudentsForm-submit");
+
+        const upload = screen.getByTestId("StudentsForm-upload");
+        const submitButton = screen.getByTestId("StudentsForm-submit");
+        userEvent.upload(upload, file);
+        fireEvent.click(submitButton);
+        expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
+
+        expect(upload.files).toHaveLength(1);
+        expect(upload.files[0]).toStrictEqual(file);
+    });
+
+});

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,6 +1,14 @@
 import {render, fireEvent, screen} from "@testing-library/react";
 import StudentsForm from "../../../main/components/Students/StudentsForm";
 import userEvent from "@testing-library/user-event";
+import {act} from "react-dom/test-utils";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("StudentsForm Tests", () => {
     /*
@@ -9,32 +17,39 @@ describe("StudentsForm Tests", () => {
     -to-simulate-file-upload-to-a-input-type-file-e
     Told me how to upload a file, and the simulation of comparing it on lines 32 and 39, and 40
     */
-    const file = new File(['there'], 'roster.csv', {type: '.csv'})
+    const mockSubmitAction = jest.fn()
+    const file = new File(['there'], 'roster.csv', {type: 'text/csv'})
     test("Required fires when there's no input", async () => {
         render(
-            <StudentsForm/>
+            <StudentsForm />
         );
         await screen.findByTestId("StudentsForm-submit");
 
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        fireEvent.click(submitButton);
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
         await screen.findByText(/Roster is required/);
     });
 
     test("No errors on good submit", async () => {
+        const user = userEvent.setup();
         render(
-            <StudentsForm/>
+            <StudentsForm submitAction={mockSubmitAction}/>
         );
         await screen.findByTestId("StudentsForm-submit");
 
         const upload = screen.getByTestId("StudentsForm-upload");
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        userEvent.upload(upload, file);
-        fireEvent.click(submitButton);
+        await user.upload(upload, file);
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
         expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
 
         expect(upload.files).toHaveLength(1);
         expect(upload.files[0]).toStrictEqual(file);
     });
+
 
 });

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -26,9 +26,7 @@ describe("StudentsForm Tests", () => {
         await screen.findByTestId("StudentsForm-submit");
 
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        await act(async () => {
-            fireEvent.click(submitButton);
-        });
+        fireEvent.click(submitButton);
         await screen.findByText(/Roster is required/);
     });
 
@@ -42,9 +40,7 @@ describe("StudentsForm Tests", () => {
         const upload = screen.getByTestId("StudentsForm-upload");
         const submitButton = screen.getByTestId("StudentsForm-submit");
         await user.upload(upload, file);
-        await act(async () => {
-            fireEvent.click(submitButton);
-        });
+        fireEvent.click(submitButton);
         expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
 
         expect(upload.files).toHaveLength(1);

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,7 +1,6 @@
 import {render, fireEvent, screen} from "@testing-library/react";
 import StudentsForm from "../../../main/components/Students/StudentsForm";
 import userEvent from "@testing-library/user-event";
-import {act} from "react-dom/test-utils";
 
 const mockedNavigate = jest.fn();
 


### PR DESCRIPTION
In this PR, I added a StudentForm where you can upload a roster of students. It is storybook-only, and yet to be implemented into CourseShowPage, and will be in a different PR.

Closes #40

Storybook:
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/92ed1f85-06d6-4d5c-b98d-eb993231e074)

Link to: https://ucsb-cs156-s24.github.io/proj-organic-s24-5pm-4/prs/42/storybook/?path=/story/components-students-studentsform--default

Designed for a smaller form factor to fit next to the StudentsTable on CourseShowPage. 
