### PR TITLE
Refactored Course Show Page to include Student Table

### DIFF
--- a/frontend/src/fixtures/studentFixture.js
+++ b/frontend/src/fixtures/studentFixture.js
@@ -1,0 +1,30 @@
+const studentFixture = {
+
+    oneStudent: {
+        "id": 1,
+        "courseId": 1,
+        "githubId": "gubinhti"
+    },
+
+    threeStudent: [
+        { 
+            "id": 1,
+            "courseId": 1,
+            "githubId": "gubinhti"
+     
+        },
+        {
+            "id": 2,
+            "courseId": 2,
+            "githubId": "royalslate"
+        },
+        {
+            "id": 3,
+            "courseId": 3,
+            "githubId": "division7"
+        }
+    ]
+};
+
+
+export { studentFixture };

--- a/frontend/src/main/components/Student/StudentTable.js
+++ b/frontend/src/main/components/Student/StudentTable.js
@@ -1,0 +1,29 @@
+import React from "react";
+import OurTable from "main/components/OurTable"
+
+
+ export default function StudentTable({ student }) {
+
+     // Stryker disable next-line all : TODO try to make a good test for this
+
+     const columns = [
+         {
+             Header: 'id',
+             accessor: 'id',
+         },
+         {
+             Header: 'courseId',
+             accessor: 'courseId',
+         },
+         {
+             Header: 'githubId',
+             accessor: 'githubId',
+         },
+   
+     ];
+
+     return <OurTable
+         data={student}
+         columns={columns}
+         testid={"StudentTable"} />;
+    };

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -51,7 +51,7 @@ export default function CoursesShowPage() {
                 <h1>Course</h1>
                 <CoursesTable courses={passIn} currentUser={currentUser}/>
             </div>
-            <div className="row">
+            <div className="row pt-3">
                 <div className="col col-8">
                     <StudentTable student={students} />
                 </div>

--- a/frontend/src/main/pages/CoursesShowPage.js
+++ b/frontend/src/main/pages/CoursesShowPage.js
@@ -4,6 +4,7 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CoursesTable from 'main/components/Courses/CoursesTable';
 import { useCurrentUser} from 'main/utils/currentUser';
 import {useParams} from "react-router-dom";
+import StudentTable from "../components/Student/StudentTable";
 
 export default function CoursesShowPage() {
     let { id } = useParams();
@@ -22,6 +23,20 @@ export default function CoursesShowPage() {
             },
     []
         );
+
+    const { data: students, error: _studenterror, status: _studentStatus } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/students/all?courseId=${id}`],
+
+            { // Stryker disable next-line all : GET is the default
+                method: "GET", url: "/api/students/all",
+                params: {
+                    courseId:id
+                },
+            },
+            []
+        );
     //this ensures the table row doesn't show up when there's no backend
     let passIn;
     if(courses.length !== 0){
@@ -35,6 +50,14 @@ export default function CoursesShowPage() {
             <div className="pt-2">
                 <h1>Course</h1>
                 <CoursesTable courses={passIn} currentUser={currentUser}/>
+            </div>
+            <div className="row">
+                <div className="col col-8">
+                    <StudentTable student={students} />
+                </div>
+                <div className="col col-4">
+                    This is a placeholder for the not yet implemented roster upload form.
+                </div>
             </div>
         </BasicLayout>
     )

--- a/frontend/src/stories/components/Student/StudentTable.stories.js
+++ b/frontend/src/stories/components/Student/StudentTable.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import StudentTable from 'main/components/Student/StudentTable';
+import { studentFixture } from 'fixtures/studentFixture';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/Student/StudentTable',
+    component: StudentTable
+};
+
+const Template = (args) => {
+    return (
+        <StudentTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    student: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    student: studentFixture.threeStudent,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    student: studentFixture.threeStudent,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/course/student/all', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/stories/pages/CoursesShowPage.stories.js
+++ b/frontend/src/stories/pages/CoursesShowPage.stories.js
@@ -5,6 +5,7 @@ import { coursesFixtures } from "fixtures/coursesFixtures";
 import { rest } from "msw";
 
 import CoursesShowPage from "main/pages/CoursesShowPage";
+import {studentFixture} from "../../fixtures/studentFixture";
 
 export default {
     title: 'pages/Courses/CoursesShowPage',
@@ -24,6 +25,9 @@ Default.parameters = {
         }),
         rest.get('/api/courses/get', (_req, res, ctx) => {
             return res(ctx.json(coursesFixtures.threeCourses[0]));
+        }),
+        rest.get('/api/students/all', (_req, res, ctx) => {
+            return res(ctx.json(studentFixture.threeStudent));
         }),
     ],
 }

--- a/frontend/src/tests/components/Student/StudentTable.test.js
+++ b/frontend/src/tests/components/Student/StudentTable.test.js
@@ -1,0 +1,139 @@
+import StudentTable from "main/components/Student/StudentTable"
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+// import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import {  render, screen } from "@testing-library/react";
+import { studentFixture } from "fixtures/studentFixture";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("StudentTable tests", () => {
+  const queryClient = new QueryClient();
+  const expectedHeaders = ["id", "courseId", "githubId"];
+  const expectedFields = ["id", "courseId", "githubId"]; 
+  const testId = "StudentTable";
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedStudentgithub = studentFixture.threeStudent;
+    expectedStudentgithub.forEach((student, index) => {
+      const githubIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-githubId`);
+      expect(githubIdCell).toHaveTextContent(student.githubId);
+    });
+
+    const expectedStudentcourse = studentFixture.threeStudent;
+    expectedStudentcourse.forEach((studentMember, index) => {
+      const courseIdCell = screen.getByTestId(`StudentTable-cell-row-${index}-col-courseId`);
+      expect(courseIdCell).toHaveTextContent(studentMember.courseId);
+    });
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+
+    
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("renders empty table correctly", () => {
+
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+
+    // act
+    render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+          <StudentTable student={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+            <StudentTable student={studentFixture.threeStudent} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    // const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    // expect(deleteButton).toBeInTheDocument();
+    // expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+
+
+
+  
+
+});

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -10,6 +10,7 @@ import { coursesFixtures } from "fixtures/coursesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
+import {studentFixture} from "../../fixtures/studentFixture";
 
 
 const mockToast = jest.fn();
@@ -170,6 +171,60 @@ describe("CoursesShowPage tests", () => {
         const show = screen.queryByTestId(`${testId}-cell-row-0-col-Show-button`);
         expect(show).not.toBeInTheDocument();
     });
+
+    test("No crashes when no backend for table ", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onGet("/api/students/all", {params: {courseId: 17}}).timeout();
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("Table renders correctly for admin", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onGet("/api/students/all", {params: {courseId: 17}}).reply(200, studentFixture.threeStudent);
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`StudentTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`StudentTable-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`StudentTable-cell-row-2-col-id`)).toHaveTextContent("3");
+    });
+
+    test("Table renders correctly for instructor", async () => {
+        setupInstructorUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
+        axiosMock.onGet("/api/students/all", {params: {courseId: 17}}).reply(200, studentFixture.threeStudent);
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesShowPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`StudentTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`StudentTable-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`StudentTable-cell-row-2-col-id`)).toHaveTextContent("3");
+    });
+
 
 });
 

--- a/frontend/src/tests/pages/CoursesShowPage.test.js
+++ b/frontend/src/tests/pages/CoursesShowPage.test.js
@@ -172,7 +172,7 @@ describe("CoursesShowPage tests", () => {
         expect(show).not.toBeInTheDocument();
     });
 
-    test("No crashes when no backend for table ", async () => {
+    test("No crashes when no backend for table, and table doesn't have headers", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, coursesFixtures.threeCourses[0]);
@@ -185,6 +185,7 @@ describe("CoursesShowPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+        expect(screen.queryByTestId(`StudentTable-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
     test("Table renders correctly for admin", async () => {


### PR DESCRIPTION
### Merge after #39
In this PR, I refactored the Individual Course Page (Course Show Page) to include the table of students who are enrolled in the course. I pre-prepped and left room for the instructor roster upload on the right hand side. 100% test coverage and kills all mutations. Will re-merge main and student table when that PR is updated.
Closes #17 

Changes are visible at https://organic-testbed.dokku-12.cs.ucsb.edu/
