### PR TITLE
Refactor Courses to link to a backend school [NON-ASSIGNED]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
-        "@testing-library/user-event": "^12.8.3",
+        "@testing-library/user-event": "^14.5.2",
         "axios": "^0.21.1",
         "babel-loader": "8.1.0",
         "bootstrap": "^5.0.0-beta3",
@@ -11507,14 +11507,11 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-      "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
-    "@testing-library/user-event": "^12.8.3",
+    "@testing-library/user-event": "^14.5.2",
     "axios": "^0.21.1",
     "babel-loader": "8.1.0",
     "bootstrap": "^5.0.0-beta3",

--- a/frontend/src/fixtures/coursesFixtures.js
+++ b/frontend/src/fixtures/coursesFixtures.js
@@ -2,39 +2,67 @@ const coursesFixtures = {
     oneCourse: {
         "id": 1,
         "name": "CS156",
-        "school": "UCSB",
+        "schoolAbbrev": "ucsb",
         "term": "F23",
         "startDate": "2023-09-24T12:00:00",
         "endDate": "2023-12-15T12:00:00",
-        "githubOrg": "ucsb-cs156-f23"
+        "githubOrg": "ucsb-cs156-f23",
+        "school": {
+            "abbrev": "ucsb",
+            "name": "UC Santa Barbara",
+            "termRegex": ".*",
+            "termDescription": "f23",
+            "termError": "ucsb"
+        }
     },
     threeCourses: [
         { 
             "id": 1,
             "name": "CS156",
-            "school": "UCSB",
+            "schoolAbbrev": "ucsb",
             "term": "F23",
             "startDate": "2023-09-24T12:00:00",
             "endDate": "2023-12-15T12:00:00",
-            "githubOrg": "ucsb-cs156-f23"
+            "githubOrg": "ucsb-cs156-f23",
+            "school": {
+                "abbrev": "ucsb",
+                "name": "UC Santa Barbara",
+                "termRegex": ".*",
+                "termDescription": "f23",
+                "termError": "ucsb"
+            }
         },
         {
             "id": 2,
             "name": "CS185",
-            "school": "UCSB",
+            "schoolAbbrev": "ucsb",
             "term": "W24",
             "startDate": "2024-01-08T12:00:00",
             "endDate": "2024-03-22T12:00:00",
-            "githubOrg": "ucsb-cs185-w24"
+            "githubOrg": "ucsb-cs185-w24",
+            "school": {
+                "abbrev": "ucsb",
+                "name": "UC Santa Barbara",
+                "termRegex": ".*",
+                "termDescription": "f23",
+                "termError": "ucsb"
+            }
         },
         {
             "id": 3,
             "name": "CS170",
-            "school": "UCSB",
+            "schoolAbbrev": "ucsb",
             "term": "S24",
             "startDate": "2024-04-01T12:00:00",
             "endDate": "2024-06-14T12:00:00",
-            "githubOrg": "ucsb-cs170-s24"
+            "githubOrg": "ucsb-cs170-s24",
+            "school": {
+                "abbrev": "ucsb",
+                "name": "UC Santa Barbara",
+                "termRegex": ".*",
+                "termDescription": "f23",
+                "termError": "ucsb"
+            }
         }
     ]
 };

--- a/frontend/src/main/components/Courses/CoursesTable.js
+++ b/frontend/src/main/components/Courses/CoursesTable.js
@@ -48,7 +48,7 @@ import React from "react";
          },
          {
              Header: 'School',
-             accessor: 'school',
+             accessor: d=> d.school.name,
          },
          {
              Header: 'Term',

--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -12,20 +12,20 @@ const SchoolDropdown = ({schools = [], testId}) => {
         <Form.Label htmlFor="school">School</Form.Label>
         <Form.Control data-testid={`${testId}-school`} id="school"  as="select"
           isInvalid={Boolean(errors.school)}
-          {...register("school", {required: true, minLength: 2})}
+          {...register("schoolAbbrev", {required: true, minLength: 2})}
         >
             <option value=""></option>
             {schools.map(function (object, i) {
                 const key = `${testId}-option-${i}`
                 return(
-                    <option key={key} data-testid={key} value={object.name}>
+                    <option key={key} data-testid={key} value={object.abbrev}>
                         {object.name}
                     </option>
                 );
             })}
         </Form.Control>
         <Form.Control.Feedback type="invalid">
-            {errors.school && 'School is required. '}
+            {errors.schoolAbbrev && 'School is required. '}
         </Form.Control.Feedback>
     </Form.Group>);
 }

--- a/frontend/src/main/components/Students/StudentsForm.js
+++ b/frontend/src/main/components/Students/StudentsForm.js
@@ -1,0 +1,40 @@
+import {useForm} from "react-hook-form";
+import {Button, Form, Row} from "react-bootstrap";
+import React from "react";
+
+function StudentsForm({submitAction}){
+    const {
+        register,
+        formState: {errors},
+        handleSubmit
+    } = useForm()
+
+    return(
+        <Form onSubmit={handleSubmit(submitAction)}>
+            <Row>
+                <Form.Group className="mb-2">
+                    <Form.Label htmlFor="upload">Upload Student Roster</Form.Label>
+                    <Form.Control data-testid="StudentsForm-upload"
+                                  id="upload"
+                                  type="file"
+                                  accept=".csv"
+                                  isInvalid={Boolean(errors.upload)}
+                        {...register("upload", {required:true})} />
+                </Form.Group>
+                <Form.Control.Feedback type="invalid">
+                    {errors.upload && 'Roster is required. '}
+                </Form.Control.Feedback>
+            </Row>
+            <Row>
+                <Button type="submit"
+                        data-testid="StudentsForm-submit"
+                        className="mb-3"
+                >
+                    Upload
+                </Button>
+            </Row>
+        </Form>
+    );
+}
+
+export default StudentsForm

--- a/frontend/src/main/components/Students/StudentsForm.js
+++ b/frontend/src/main/components/Students/StudentsForm.js
@@ -20,10 +20,10 @@ function StudentsForm({submitAction}){
                                   accept=".csv"
                                   isInvalid={Boolean(errors.upload)}
                         {...register("upload", {required:true})} />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.upload && 'Roster is required. '}
+                    </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Control.Feedback type="invalid">
-                    {errors.upload && 'Roster is required. '}
-                </Form.Control.Feedback>
             </Row>
             <Row>
                 <Button type="submit"

--- a/frontend/src/main/pages/CoursesCreatePage.js
+++ b/frontend/src/main/pages/CoursesCreatePage.js
@@ -11,7 +11,7 @@ export default function CoursesCreatePage({storybook=false}) {
         method: "POST",
         params: {
         name: course.name,
-        school: course.school,
+        schoolAbbrev: course.schoolAbbrev,
         term: course.term,
         startDate: course.startDate,
         endDate: course.endDate,

--- a/frontend/src/main/pages/CoursesEditPage.js
+++ b/frontend/src/main/pages/CoursesEditPage.js
@@ -28,7 +28,7 @@ export default function CoursesEditPage({storybook=false}) {
     params: {
       id: course.id,
       name: course.name,
-      school: course.school,
+      schoolAbbrev: course.schoolAbbrev,
       term: course.term,
       startDate: course.startDate,
       endDate: course.endDate,

--- a/frontend/src/stories/components/Students/StudentsForm.stories.js
+++ b/frontend/src/stories/components/Students/StudentsForm.stories.js
@@ -1,0 +1,22 @@
+import StudentsForm from "../../../main/components/Students/StudentsForm";
+
+
+export default{
+    title: "components/Students/StudentsForm",
+    component: StudentsForm
+}
+
+const Template = (args) => {
+    return(
+        <StudentsForm {...args} />
+    );
+}
+
+export const Default = Template.bind({});
+
+Default.args={
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data);
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+}

--- a/frontend/src/tests/components/Courses/CoursesForm.test.js
+++ b/frontend/src/tests/components/Courses/CoursesForm.test.js
@@ -119,7 +119,7 @@ describe("CoursesForm tests", () => {
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(nameField, { target: { value: "CMPSC 156" } });
-        fireEvent.change(schoolField, { target: { value: 'UC Santa Barbara' } });
+        fireEvent.change(schoolField, { target: { value: 'ucsb' } });
         fireEvent.change(termField, { target: { value: 'f23' } });
         fireEvent.change(startDateField, { target: { value: '2022-01-02T12:00' } });
         fireEvent.change(endDateField, { target: { value: '2022-02-02T12:00' } });

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -179,6 +179,8 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
 
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-School`)).toHaveTextContent("UC Santa Barbara");
+
     const joinButton = screen.queryByTestId(`${testId}-cell-row-0-col-Join-button`);
     expect(joinButton).toBeInTheDocument(); 
 

--- a/frontend/src/tests/components/Courses/CoursesTable.test.js
+++ b/frontend/src/tests/components/Courses/CoursesTable.test.js
@@ -30,7 +30,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const expectedFields = ["id", "name", "School", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -72,7 +72,7 @@ describe("UserTable tests", () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
     const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const expectedFields = ["id", "name", "School", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
     
     // act
@@ -114,7 +114,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const expectedFields = ["id", "name", "School", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -163,7 +163,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Name", "School", "Term", "StartDate", "EndDate", "GitHub Org"];
-    const expectedFields = ["id", "name", "school", "term", "startDate", "endDate", "githubOrg"];
+    const expectedFields = ["id", "name", "School", "term", "startDate", "endDate", "githubOrg"];
     const testId = "CoursesTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,0 +1,40 @@
+import {render, fireEvent, screen} from "@testing-library/react";
+import StudentsForm from "../../../main/components/Students/StudentsForm";
+import userEvent from "@testing-library/user-event";
+
+describe("StudentsForm Tests", () => {
+    /*
+    Thank you stack overflow for this tip
+    https://stackoverflow.com/questions/61104842/react-testing-library-how
+    -to-simulate-file-upload-to-a-input-type-file-e
+    Told me how to upload a file, and the simulation of comparing it on lines 32 and 39, and 40
+    */
+    const file = new File(['there'], 'roster.csv', {type: '.csv'})
+    test("Required fires when there's no input", async () => {
+        render(
+            <StudentsForm/>
+        );
+        await screen.findByTestId("StudentsForm-submit");
+
+        const submitButton = screen.getByTestId("StudentsForm-submit");
+        fireEvent.click(submitButton);
+        await screen.findByText(/Roster is required/);
+    });
+
+    test("No errors on good submit", async () => {
+        render(
+            <StudentsForm/>
+        );
+        await screen.findByTestId("StudentsForm-submit");
+
+        const upload = screen.getByTestId("StudentsForm-upload");
+        const submitButton = screen.getByTestId("StudentsForm-submit");
+        userEvent.upload(upload, file);
+        fireEvent.click(submitButton);
+        expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
+
+        expect(upload.files).toHaveLength(1);
+        expect(upload.files[0]).toStrictEqual(file);
+    });
+
+});

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,6 +1,14 @@
 import {render, fireEvent, screen} from "@testing-library/react";
 import StudentsForm from "../../../main/components/Students/StudentsForm";
 import userEvent from "@testing-library/user-event";
+import {act} from "react-dom/test-utils";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("StudentsForm Tests", () => {
     /*
@@ -9,32 +17,39 @@ describe("StudentsForm Tests", () => {
     -to-simulate-file-upload-to-a-input-type-file-e
     Told me how to upload a file, and the simulation of comparing it on lines 32 and 39, and 40
     */
-    const file = new File(['there'], 'roster.csv', {type: '.csv'})
+    const mockSubmitAction = jest.fn()
+    const file = new File(['there'], 'roster.csv', {type: 'text/csv'})
     test("Required fires when there's no input", async () => {
         render(
-            <StudentsForm/>
+            <StudentsForm />
         );
         await screen.findByTestId("StudentsForm-submit");
 
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        fireEvent.click(submitButton);
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
         await screen.findByText(/Roster is required/);
     });
 
     test("No errors on good submit", async () => {
+        const user = userEvent.setup();
         render(
-            <StudentsForm/>
+            <StudentsForm submitAction={mockSubmitAction}/>
         );
         await screen.findByTestId("StudentsForm-submit");
 
         const upload = screen.getByTestId("StudentsForm-upload");
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        userEvent.upload(upload, file);
-        fireEvent.click(submitButton);
+        await user.upload(upload, file);
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
         expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
 
         expect(upload.files).toHaveLength(1);
         expect(upload.files[0]).toStrictEqual(file);
     });
+
 
 });

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -26,9 +26,7 @@ describe("StudentsForm Tests", () => {
         await screen.findByTestId("StudentsForm-submit");
 
         const submitButton = screen.getByTestId("StudentsForm-submit");
-        await act(async () => {
-            fireEvent.click(submitButton);
-        });
+        fireEvent.click(submitButton);
         await screen.findByText(/Roster is required/);
     });
 
@@ -42,9 +40,7 @@ describe("StudentsForm Tests", () => {
         const upload = screen.getByTestId("StudentsForm-upload");
         const submitButton = screen.getByTestId("StudentsForm-submit");
         await user.upload(upload, file);
-        await act(async () => {
-            fireEvent.click(submitButton);
-        });
+        fireEvent.click(submitButton);
         expect(screen.queryByText(/Roster is required/)).not.toBeInTheDocument();
 
         expect(upload.files).toHaveLength(1);

--- a/frontend/src/tests/components/Students/StudentsForm.test.js
+++ b/frontend/src/tests/components/Students/StudentsForm.test.js
@@ -1,7 +1,6 @@
 import {render, fireEvent, screen} from "@testing-library/react";
 import StudentsForm from "../../../main/components/Students/StudentsForm";
 import userEvent from "@testing-library/user-event";
-import {act} from "react-dom/test-utils";
 
 const mockedNavigate = jest.fn();
 

--- a/frontend/src/tests/pages/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/CoursesCreatePage.test.js
@@ -60,7 +60,7 @@ describe("CourseCreatePage tests", () => {
         const course = {
             id: 1,
             name: "CS156",
-            school: "UC Santa Barbara",
+            schoolAbbrev: "ucsb",
             term: "F23",
             startDate: "2023-09-24T12:00:00",
             endDate: "2023-12-15T12:00:00",
@@ -90,7 +90,7 @@ describe("CourseCreatePage tests", () => {
         const submitButton = screen.getByTestId("CoursesForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'CS156' } });
-        fireEvent.change(schoolField, { target: { value: 'UC Santa Barbara' } });
+        fireEvent.change(schoolField, { target: { value: 'ucsb' } });
         fireEvent.change(termField, { target: { value: 'F23' } });
         fireEvent.change(startDateField, { target: { value: '2023-09-24T12:00:00' } });
         fireEvent.change(endDateField, { target: { value: '2023-12-15T12:00:00' } });
@@ -105,7 +105,7 @@ describe("CourseCreatePage tests", () => {
         expect(axiosMock.history.post[0].params).toEqual(
             {
                 "name": "CS156",
-                "school": "UC Santa Barbara",
+                "schoolAbbrev": "ucsb",
                 "term": "F23",
                 "startDate": "2023-09-24T12:00",
                 "endDate": "2023-12-15T12:00",

--- a/frontend/src/tests/pages/CoursesEditPage.test.js
+++ b/frontend/src/tests/pages/CoursesEditPage.test.js
@@ -83,17 +83,24 @@ describe("CoursesEditPage tests", () => {
             axiosMock.onGet("/api/schools/all").reply(200, schoolsFixtures.threeSchools);
             axiosMock.onGet("/api/courses/get", { params: { id: 17 } }).reply(200, {
                 id: 17,
-                name: "CS 156",
-                school: "UC Santa Barbara",
+                name: "CS156",
+                schoolAbbrev: "ucsb",
                 term: "f23",
-                startDate: "2023-09-29T00:00",
-                endDate: "2023-12-15T00:00",
-                githubOrg: "ucsb-cs156-f23"
+                startDate: "2023-09-24T12:00:00",
+                endDate: "2023-12-15T12:00:00",
+                githubOrg: "ucsb-cs156-f23",
+                school: {
+                    abbrev: "ucsb",
+                    name: "UC Santa Barbara",
+                    termRegex: ".*",
+                    termDescription: "f23",
+                    termError: "ucsb"
+                }
             });
             axiosMock.onPut('/api/courses/update').reply(200, {
                 id: "17",
                 name: "CS 148",
-                school: "UC Santa Barbara",
+                schoolAbbrev: "ucsb",
                 term: "w23",
                 startDate: "2024-01-10T00:00",
                 endDate: "2023-03-12T00:00",
@@ -134,11 +141,11 @@ describe("CoursesEditPage tests", () => {
             const submitButton = screen.getByTestId("CoursesForm-submit");
 
             expect(idField).toHaveValue("17");
-            expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UC Santa Barbara");
+            expect(nameField).toHaveValue("CS156");
+            expect(schoolField).toHaveValue("ucsb");
             expect(termField).toHaveValue("f23");
-            expect(startField).toHaveValue("2023-09-29T00:00");
-            expect(endField).toHaveValue("2023-12-15T00:00");
+            expect(startField).toHaveValue("2023-09-24T12:00");
+            expect(endField).toHaveValue("2023-12-15T12:00");
             expect(githubOrgField).toHaveValue("ucsb-cs156-f23");
             expect(submitButton).toBeInTheDocument();
         });
@@ -165,16 +172,16 @@ describe("CoursesEditPage tests", () => {
             const submitButton = screen.getByTestId("CoursesForm-submit");
 
             expect(idField).toHaveValue("17");
-            expect(nameField).toHaveValue("CS 156");
-            expect(schoolField).toHaveValue("UC Santa Barbara");
+            expect(nameField).toHaveValue("CS156");
+            expect(schoolField).toHaveValue("ucsb");
             expect(termField).toHaveValue("f23");
-            expect(startField).toHaveValue("2023-09-29T00:00");
-            expect(endField).toHaveValue("2023-12-15T00:00");
+            expect(startField).toHaveValue("2023-09-24T12:00");
+            expect(endField).toHaveValue("2023-12-15T12:00");
             expect(githubOrgField).toHaveValue("ucsb-cs156-f23");
             expect(submitButton).toBeInTheDocument();
 
             fireEvent.change(nameField, { target: { value: "CS 148" } })
-            fireEvent.change(schoolField, { target: { value: "University of Minnesota" } })
+            fireEvent.change(schoolField, { target: { value: "umn" } })
             fireEvent.change(termField, { target: { value: "w23" } })
             fireEvent.change(startField, { target: { value: "2024-01-10T00:00" } })
             fireEvent.change(endField, { target: { value: "2023-03-12T00:00" } })
@@ -187,7 +194,9 @@ describe("CoursesEditPage tests", () => {
             expect(mockNavigate).toBeCalledWith({ "to": "/courses" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", school: "University of Minnesota", term: "w23", githubOrg: "ucsb-cs156-w23" });
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17, name: "CS 148", endDate: "2023-03-12T00:00", startDate: "2024-01-10T00:00", schoolAbbrev: "umn", term: "w23", githubOrg: "ucsb-cs156-w23",
+
+            });
 
         });
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -1,9 +1,11 @@
 package edu.ucsb.cs156.organic.controllers;
 
 import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.School;
 import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
+import edu.ucsb.cs156.organic.repositories.SchoolRepository;
 import edu.ucsb.cs156.organic.repositories.StaffRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,6 +51,9 @@ public class CoursesController extends ApiController {
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    SchoolRepository schoolRepository;
+
     @Operation(summary = "List all courses")
     @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/all")
@@ -86,20 +91,24 @@ public class CoursesController extends ApiController {
     @PostMapping("/post")
     public Course postCourse(
             @Parameter(name = "name", description = "course name, e.g. CMPSC 156") @RequestParam String name,
-            @Parameter(name = "school", description = "school abbreviation e.g. UCSB") @RequestParam String school,
+            @Parameter(name = "schoolAbbrev", description = "school abbreviation e.g. UCSB") @RequestParam String schoolAbbrev,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
             @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23") @RequestParam String githubOrg)
             throws JsonProcessingException {
 
+        School school =  schoolRepository.findById(schoolAbbrev)
+                .orElseThrow(() -> new EntityNotFoundException(School.class, schoolAbbrev));
+
         Course course = Course.builder()
                 .name(name)
-                .school(school)
+                .schoolAbbrev(schoolAbbrev)
                 .term(term)
                 .startDate(startDate)
                 .endDate(endDate)
                 .githubOrg(githubOrg)
+                .school(school)
                 .build();
 
         Course savedCourse = courseRepository.save(course);
@@ -176,7 +185,7 @@ public class CoursesController extends ApiController {
     public Course updateCourse(
             @Parameter(name = "id") @RequestParam Long id,
             @Parameter(name = "name", description = "course name, e.g. CMPSC 156") @RequestParam String name,
-            @Parameter(name = "school", description = "school abbreviation e.g. UCSB") @RequestParam String school,
+            @Parameter(name = "schoolAbbrev", description = "school abbreviation e.g. UCSB") @RequestParam String schoolAbbrev,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
             @Parameter(name = "startDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
             @Parameter(name = "endDate", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
@@ -196,12 +205,16 @@ public class CoursesController extends ApiController {
                             "User is not a staff member for this course"));
         }
 
+        School school =  schoolRepository.findById(schoolAbbrev)
+                .orElseThrow(() -> new EntityNotFoundException(School.class, schoolAbbrev));
+
         course.setName(name);
         course.setSchool(school);
         course.setTerm(term);
         course.setStartDate(startDate);
         course.setEndDate(endDate);
         course.setGithubOrg(githubOrg);
+        course.setSchoolAbbrev(school.getAbbrev());
 
         course = courseRepository.save(course);
         log.info("course={}", course);

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Course.java
@@ -17,10 +17,14 @@ public class Course {
   private long id;
 
   private String name;
-  private String school;
+  private String schoolAbbrev;
   private String term;
   private LocalDateTime startDate;
   private LocalDateTime endDate;
   private String githubOrg;
+
+  @OneToOne
+  @JoinColumn(name = "schoolAbbrev", referencedColumnName = "abbrev", insertable = false, updatable = false)
+  private School school;
   
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/SchoolRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/SchoolRepository.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 @Repository
 public interface SchoolRepository extends CrudRepository<School, String> {
-    // You can add custom query methods here if needed
-    // Optional<School> findById(String id);
+    Optional<School> findById(String id);
 }
 

--- a/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
+++ b/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
@@ -52,7 +52,7 @@
               },
               {
                 "column": {
-                  "name": "SCHOOL",
+                  "name": "SCHOOL_ABBREV",
                   "type": "VARCHAR(255)"
                 }
               },

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.organic.entities.School;
+import edu.ucsb.cs156.organic.repositories.SchoolRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,30 +79,42 @@ public class CoursesControllerTests extends ControllerTestCase {
     @MockBean
     StaffRepository courseStaffRepository;
 
+    @MockBean
+    SchoolRepository schoolRepository;
+
     @Autowired
     CurrentUserService userService;
 
     @Autowired
     ObjectMapper objectMapper;
 
+    School school = School.builder()
+            .abbrev("UCSB")
+            .name("UC Santa Barbara")
+            .termRegex("[WSMF]\\d\\d")
+            .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+            .termError("Quarter must be entered in the correct format")
+            .build();
     Course course1 = Course.builder()
             .id(1L)
             .name("CS156")
-            .school("UCSB")
+            .schoolAbbrev(school.getAbbrev())
             .term("F23")
             .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
             .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
             .githubOrg("ucsb-cs156-f23")
+            .school(school)
             .build();
 
     Course course2 = Course.builder()
             .id(1L)
             .name("CS148")
-            .school("UCSB")
+            .schoolAbbrev(school.getAbbrev())
             .term("S24")
             .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
             .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
             .githubOrg("ucsb-cs148-w24")
+            .school(school)
             .build();
 
     @WithMockUser(roles = { "ADMIN" })
@@ -246,31 +260,41 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     public void an_admin_user_can_post_a_new_course() throws Exception {
         // arrange
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
 
         Course courseBefore = Course.builder()
-                .name("CS16")
-                .school("UCSB")
+                .id(1L)
+                .name("CS156")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .githubOrg("ucsb-cs156-f23")
+                .school(school)
                 .build();
 
         Course courseAfter = Course.builder()
-                .id(222L)
-                .name("CS16")
-                .school("UCSB")
-                .term("F23")
-                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
-                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .id(1L)
+                .name("CS148")
+                .schoolAbbrev(school.getAbbrev())
+                .term("S24")
+                .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
+                .githubOrg("ucsb-cs148-w24")
+                .school(school)
                 .build();
 
         when(courseRepository.save(eq(courseBefore))).thenReturn(courseAfter);
-
+        when(schoolRepository.findById(any())).thenReturn(Optional.of(school));
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/courses/post?name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                post("/api/courses/post?name=CS156&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs156-f23")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -285,31 +309,42 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     public void an_instructor_can_post_a_new_course() throws Exception {
         // arrange
-
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
+        System.out.println(school);
         Course courseBefore = Course.builder()
-                .name("CS16")
-                .school("UCSB")
+                .id(1L)
+                .name("CS156")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .githubOrg("ucsb-cs156-f23")
+                .school(school)
                 .build();
 
         Course courseAfter = Course.builder()
-                .id(222L)
-                .name("CS16")
-                .school("UCSB")
-                .term("F23")
-                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
-                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .id(1L)
+                .name("CS148")
+                .schoolAbbrev(school.getAbbrev())
+                .term("S24")
+                .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
+                .githubOrg("ucsb-cs148-w24")
+                .school(school)
                 .build();
 
+        when(schoolRepository.findById(any())).thenReturn(Optional.of(school));
         when(courseRepository.save(eq(courseBefore))).thenReturn(courseAfter);
 
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/courses/post?name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                post("/api/courses/post?name=CS156&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -327,29 +362,32 @@ public class CoursesControllerTests extends ControllerTestCase {
         // arrange
 
         Course courseBefore = Course.builder()
-                .name("CS16")
-                .school("UCSB")
+                .id(1L)
+                .name("CS156")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .githubOrg("ucsb-cs156-f23")
+                .school(school)
                 .build();
 
         Course courseAfter = Course.builder()
-                .id(222L)
-                .name("CS16")
-                .school("UCSB")
-                .term("F23")
-                .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
-                .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
-                .githubOrg("ucsb-cs16-f23")
+                .id(1L)
+                .name("CS148")
+                .schoolAbbrev(school.getAbbrev())
+                .term("S24")
+                .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
+                .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
+                .githubOrg("ucsb-cs148-w24")
+                .school(school)
                 .build();
 
         when(courseRepository.save(eq(courseBefore))).thenReturn(courseAfter);
 
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/courses/post?name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                post("/api/courses/post?name=CS156&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs156-f23")
                         .with(csrf()))
                 .andExpect(status().isForbidden()).andReturn();
     
@@ -554,12 +592,19 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     public void an_admin_user_cannot_update_non_existing_course() throws Exception {
         // arrange
-
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
         when(courseRepository.findById(eq(42L))).thenReturn(Optional.empty());
+        when(schoolRepository.findById(eq(school.getAbbrev()))).thenReturn(Optional.of(school));
         // act
 
         MvcResult response = mockMvc.perform(
-                put("/api/courses/update?id=42&name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                put("/api/courses/update?id=42&name=CS156&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs156-f23")
                                 .with(csrf()))
                 .andExpect(status().isNotFound()).andReturn();
         // assert
@@ -573,18 +618,33 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     public void an_admin_user_can_update_a_course() throws Exception {
         // arrange
-
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
         Course courseBefore = course1;
 
         Course courseAfter = course2;
-        courseAfter.setSchool("UCSD");
+        School ucsd = School.builder()
+                .abbrev("UCSD")
+                .name("UC San Diego")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
+        courseAfter.setSchoolAbbrev(ucsd.getAbbrev());
+        courseAfter.setSchool(ucsd);
 
+        when(schoolRepository.findById(eq(school.getAbbrev()))).thenReturn(Optional.of(school));
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
         when(courseRepository.save(eq(courseAfter))).thenReturn(courseAfter);
 
         String urlTemplate = String.format(
-                "/api/courses/update?id=%d&name=%s&school=%s&term=%s&startDate=%s&endDate=%s&githubOrg=%s",
-                courseAfter.getId(), courseAfter.getName(), courseAfter.getSchool(), courseAfter.getTerm(),
+                "/api/courses/update?id=%d&name=%s&schoolAbbrev=%s&term=%s&startDate=%s&endDate=%s&githubOrg=%s",
+                courseAfter.getId(), courseAfter.getName(), courseAfter.getSchoolAbbrev(), courseAfter.getTerm(),
                 courseAfter.getStartDate().toString(), courseAfter.getEndDate().toString(), courseAfter.getGithubOrg());
         MvcResult response = mockMvc.perform(
                 put(urlTemplate)
@@ -606,11 +666,25 @@ public class CoursesControllerTests extends ControllerTestCase {
 
         // get current user, make sure that when courseStaffRepository.findByCourseId is
         // called, it returns the current user
-
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
         Course courseBefore = course1;
 
         Course courseAfter = course2;
-        courseAfter.setSchool("UCSD");
+        School ucsd = School.builder()
+                .abbrev("UCSD")
+                .name("UC San Diego")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
+        courseAfter.setSchoolAbbrev(ucsd.getAbbrev());
+        courseAfter.setSchool(ucsd);
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
         when(courseRepository.save(eq(courseAfter))).thenReturn(courseAfter);
@@ -622,12 +696,12 @@ public class CoursesControllerTests extends ControllerTestCase {
         when(courseStaffRepository.findByCourseIdAndGithubId(courseBefore.getId(), user.getGithubId()))
                 .thenReturn(Optional
                         .of(courseStaff));
-
+        when(schoolRepository.findById(eq(school.getAbbrev()))).thenReturn(Optional.of(school));
         // act
         // get urlTemplate from courseAfter using string interpolation
         String urlTemplate = String.format(
-                "/api/courses/update?id=%d&name=%s&school=%s&term=%s&startDate=%s&endDate=%s&githubOrg=%s",
-                courseAfter.getId(), courseAfter.getName(), courseAfter.getSchool(), courseAfter.getTerm(),
+                "/api/courses/update?id=%d&name=%s&schoolAbbrev=%s&term=%s&startDate=%s&endDate=%s&githubOrg=%s",
+                courseAfter.getId(), courseAfter.getName(), courseAfter.getSchoolAbbrev(), courseAfter.getTerm(),
                 courseAfter.getStartDate().toString(), courseAfter.getEndDate().toString(), courseAfter.getGithubOrg());
         MvcResult response = mockMvc.perform(
                 put(urlTemplate)
@@ -650,21 +724,23 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         Course courseAfter = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
@@ -679,7 +755,7 @@ public class CoursesControllerTests extends ControllerTestCase {
                 .thenReturn(notStaff);
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/courses/update?id=1&name=CS16&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                put("/api/courses/update?id=1&name=CS16&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs156-f23")
                         .with(csrf()))
                 .andExpect(status().isForbidden()).andReturn();
 
@@ -704,21 +780,23 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         Course courseAfter = Course.builder()
                 .id(1L)
                 .name("CS32")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs32-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
@@ -726,7 +804,7 @@ public class CoursesControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/courses/update?id=1&name=CS32&school=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs32-f23")
+                put("/api/courses/update?id=1&name=CS32&schoolAbbrev=UCSB&term=F23&startDate=2023-09-01T00:00:00&endDate=2023-12-31T00:00:00&githubOrg=ucsb-cs32-f23")
                         .with(csrf()))
                 .andExpect(status().isForbidden()).andReturn();
 
@@ -771,11 +849,12 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
@@ -805,11 +884,12 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
@@ -843,11 +923,12 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));
@@ -886,11 +967,12 @@ public class CoursesControllerTests extends ControllerTestCase {
         Course courseBefore = Course.builder()
                 .id(1L)
                 .name("CS16")
-                .school("UCSB")
+                .schoolAbbrev(school.getAbbrev())
                 .term("F23")
                 .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                 .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                 .githubOrg("ucsb-cs16-f23")
+                .school(school)
                 .build();
 
         when(courseRepository.findById(eq(courseBefore.getId()))).thenReturn(Optional.of(courseBefore));

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.organic.entities.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,10 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
-import edu.ucsb.cs156.organic.entities.Course;
-import edu.ucsb.cs156.organic.entities.Staff;
-import edu.ucsb.cs156.organic.entities.Student;
-import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.jobs.Job;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
 import edu.ucsb.cs156.organic.repositories.StaffRepository;
@@ -84,24 +81,34 @@ public class StudentsControllerTests extends ControllerTestCase {
         @Autowired
         ObjectMapper objectMapper;
 
+        School school = School.builder()
+                .abbrev("UCSB")
+                .name("UC Santa Barbara")
+                .termRegex("[WSMF]\\d\\d")
+                .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+                .termError("Quarter must be entered in the correct format")
+                .build();
+
         Course course1 = Course.builder()
                         .id(1L)
                         .name("CS156")
-                        .school("UCSB")
+                        .school(school)
                         .term("F23")
                         .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
                         .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
                         .githubOrg("ucsb-cs156-f23")
+                        .schoolAbbrev(school.getAbbrev())
                         .build();
 
         Course course2 = Course.builder()
                         .id(1L)
                         .name("CS148")
-                        .school("UCSB")
+                        .school(school)
                         .term("S24")
                         .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
                         .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
                         .githubOrg("ucsb-cs148-w24")
+                        .schoolAbbrev(school.getAbbrev())
                         .build();
 
         Student student1 = Student.builder()

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UserInfoControllerTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.organic.controllers;
 
+import edu.ucsb.cs156.organic.entities.School;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -121,24 +122,34 @@ public class UserInfoControllerTests extends ControllerTestCase {
     CurrentUser currentUser = currentUserService.getCurrentUser();
     User user = currentUser.getUser();
 
+    School school = School.builder()
+            .abbrev("UCSB")
+            .name("UC Santa Barbara")
+            .termRegex("[WSMF]\\d\\d")
+            .termDescription("Enter quarter, e.g. F23, W24, S24, M24")
+            .termError("Quarter must be entered in the correct format")
+            .build();
+
     Course course1 = Course.builder()
         .id(1L)
         .name("CS156")
-        .school("UCSB")
+        .school(school)
         .term("F23")
         .startDate(LocalDateTime.parse("2023-09-01T00:00:00"))
         .endDate(LocalDateTime.parse("2023-12-31T00:00:00"))
         .githubOrg("ucsb-cs156-f23")
+        .schoolAbbrev(school.getAbbrev())
         .build();
 
     Course course2 = Course.builder()
         .id(1L)
         .name("CS148")
-        .school("UCSB")
+        .school(school)
         .term("S24")
         .startDate(LocalDateTime.parse("2024-01-01T00:00:00"))
         .endDate(LocalDateTime.parse("2024-03-31T00:00:00"))
         .githubOrg("ucsb-cs148-w24")
+        .schoolAbbrev(school.getAbbrev())
         .build();
 
      ArrayList<Course> expectedCourses = new ArrayList<>();


### PR DESCRIPTION
In this PR, I realized that courses are linked to schools, and with the ability to edit school names, the dropdown could no longer link schools to courses, as if the name changed there was no record connecting them.

So, in the backend, I linked courses and schools, using courseStaff as an example, and in the frontend make the schoolDropdown values be the school abbreviation so they could be linked.

visible at https://organic-testbed.dokku-12.cs.ucsb.edu