### PR TITLE
[Bugfix] Make dropdown value show up on first render

### DIFF
--- a/frontend/src/main/components/Courses/SchoolDropdown.js
+++ b/frontend/src/main/components/Courses/SchoolDropdown.js
@@ -5,7 +5,8 @@ import {useFormContext} from "react-hook-form";
 const SchoolDropdown = ({schools = [], testId}) => {
     const {
         register,
-        formState: {errors}
+        formState: {errors},
+        formState
     } = useFormContext();
 
     return (<Form.Group>
@@ -13,6 +14,7 @@ const SchoolDropdown = ({schools = [], testId}) => {
         <Form.Control data-testid={`${testId}-school`} id="school"  as="select"
           isInvalid={Boolean(errors.school)}
           {...register("schoolAbbrev", {required: true, minLength: 2})}
+            value={formState.defaultValues.schoolAbbrev}
         >
             <option value=""></option>
             {schools.map(function (object, i) {


### PR DESCRIPTION
On main, when entering the course edit page for the first time, the selected course will not appear because the default value is applied before the options are added:

![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/79fdaf14-4cb6-4658-9a53-1faa3af55878)

Corrected on Dokku (https://organic-qa.dokku-12.cs.ucsb.edu):
![image](https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-4/assets/26347897/80cd8250-b446-470f-b10c-c5f573a44359)

For comparison, https://organic.dokku-12.cs.ucsb.edu/ is still running main

